### PR TITLE
OS detection logic fails on some Windows version, due to case-sensitivity comparing os name string

### DIFF
--- a/src/main/java/io/apisense/embed/influx/configuration/OSType.java
+++ b/src/main/java/io/apisense/embed/influx/configuration/OSType.java
@@ -26,7 +26,7 @@ public enum OSType {
      * @return The value of the currently running {@link OSType}.
      */
     public static OSType getCurrent() {
-        return System.getProperty("os.name").contains("windows") ? OSType.Windows : OSType.Linux;
+        return System.getProperty("os.name").toLowerCase().contains("windows") ? OSType.Windows : OSType.Linux;
     }
 
     public Platform toPlatform() {


### PR DESCRIPTION
Changed OS detection logic to use case-insensitive matching. Some Windows system use capital W in the java os.name property, e.g. Windows 8.1